### PR TITLE
MRSync bugfix and feature addition

### DIFF
--- a/lua/msync/client_gui/modules/cl_mrsync.lua
+++ b/lua/msync/client_gui/modules/cl_mrsync.lua
@@ -6,7 +6,7 @@ MSync.modules.MRSync = MSync.modules.MRSync or {}
  * @package    MySQL Rank Sync
  * @author     Aperture Development
  * @license    root_dir/LICENCE
- * @version    2.1.3
+ * @version    2.2.0
 ]]
 
 --[[
@@ -16,7 +16,7 @@ MSync.modules.MRSync.info = {
     Name = "MySQL Rank Sync",
     ModuleIdentifier = "MRSync",
     Description = "Synchronise your ranks across your servers",
-    Version = "2.1.3"
+    Version = "2.2.0"
 }
 
 --[[

--- a/lua/msync/server/modules/sv_mrsync.lua
+++ b/lua/msync/server/modules/sv_mrsync.lua
@@ -6,7 +6,7 @@ MSync.modules.MRSync = MSync.modules.MRSync or {}
  * @package    MySQL Rank Sync
  * @author     Aperture Development
  * @license    root_dir/LICENCE
- * @version    2.1.3
+ * @version    2.2.0
 ]]
 
 --[[
@@ -16,7 +16,7 @@ MSync.modules.MRSync.info = {
     Name = "MySQL Rank Sync",
     ModuleIdentifier = "MRSync",
     Description = "Synchronise your ranks across your servers",
-    Version = "2.1.3"
+    Version = "2.2.0"
 }
 
 --[[

--- a/lua/msync/server/modules/sv_mrsync.lua
+++ b/lua/msync/server/modules/sv_mrsync.lua
@@ -61,6 +61,23 @@ function MSync.modules.MRSync.init( transaction )
             addUserRankQ:setString(4, "allservers")
         end
 
+        addUserRankQ.onError = function( q, err, sql )
+            if string.match( err, "^Column 'user_id' cannot be null$" ) then
+                MSync.mysql.addUserID(steamid)
+                MSync.modules.MRSync.saveRankByID(steamid, group)
+            else
+                print("------------------------------------")
+                print("[MRSync] SQL Error!")
+                print("------------------------------------")
+                print("Please include this in a Bug report:\n")
+                print(err.."\n")
+                print("------------------------------------")
+                print("Do not include this, this is for debugging only:\n")
+                print(sql.."\n")
+                print("------------------------------------")
+            end
+        end
+
         addUserRankQ:start()
     end
 
@@ -97,6 +114,23 @@ function MSync.modules.MRSync.init( transaction )
 
             removeOldRanksQ.onSuccess = function( q, data )
                 MSync.modules.MRSync.saveRankByID(steamid, group)
+            end
+        end
+
+        removeOldRanksQ.onError = function( q, err, sql )
+            if string.match( err, "^Column 'user_id' cannot be null$" ) then
+                MSync.mysql.addUserID(steamid)
+                MSync.modules.MRSync.saveRankByID(steamid, group)
+            else
+                print("------------------------------------")
+                print("[MRSync] SQL Error!")
+                print("------------------------------------")
+                print("Please include this in a Bug report:\n")
+                print(err.."\n")
+                print("------------------------------------")
+                print("Do not include this, this is for debugging only:\n")
+                print(sql.."\n")
+                print("------------------------------------")
             end
         end
 


### PR DESCRIPTION
- Fixed a bug causing the allserver rank to not be prioritized
- Removed obsolete function
- Fixed a bug that caused the rank to always be re-created when the user is in a allserver group
- Removed a part of the code which is now unecessary due to our new way of saving data
- Added a function to add steamids to the database, that function will be useful for handling offline data ( player didn't join yet, but we want to ban him )
- We implemented the same addUserID technique that we have developed for MBSync, now uppon rank change of a non existing user we create the user and then save his rank to the database.
