### PR TITLE
Bugfix #56

### DIFF
--- a/lua/msync/client_gui/modules/cl_mrsync.lua
+++ b/lua/msync/client_gui/modules/cl_mrsync.lua
@@ -6,7 +6,7 @@ MSync.modules.MRSync = MSync.modules.MRSync or {}
  * @package    MySQL Rank Sync
  * @author     Aperture Development
  * @license    root_dir/LICENCE
- * @version    2.2.0
+ * @version    2.2.1
 ]]
 
 --[[
@@ -16,7 +16,7 @@ MSync.modules.MRSync.info = {
     Name = "MySQL Rank Sync",
     ModuleIdentifier = "MRSync",
     Description = "Synchronise your ranks across your servers",
-    Version = "2.2.0"
+    Version = "2.2.1"
 }
 
 --[[

--- a/lua/msync/server/modules/sv_mrsync.lua
+++ b/lua/msync/server/modules/sv_mrsync.lua
@@ -7,7 +7,7 @@ local userTransaction = userTransaction or {}
  * @package    MySQL Rank Sync
  * @author     Aperture Development
  * @license    root_dir/LICENCE
- * @version    2.2.0
+ * @version    2.2.1
 ]]
 
 --[[
@@ -17,7 +17,7 @@ MSync.modules.MRSync.info = {
     Name = "MySQL Rank Sync",
     ModuleIdentifier = "MRSync",
     Description = "Synchronise your ranks across your servers",
-    Version = "2.2.0"
+    Version = "2.2.1"
 }
 
 --[[


### PR DESCRIPTION
- Change behaviour how MRSync handles deleted ranks. If a user has been removed he gets deleted from the dabase, and if the user joins the server, the rank gets removed from him using "ulx removeuser"