### PR TITLE
Update Syntax

### DIFF
--- a/lua/msync/server/modules/sv_mbsync.lua
+++ b/lua/msync/server/modules/sv_mbsync.lua
@@ -71,8 +71,8 @@ MSync.modules[info.ModuleIdentifier].init = function( transaction )
                         MODIFY `length_unix` INT UNSIGNED NOT NULL;
                     ]]))
                     updates:addQuery( MSync.DBServer:query([[
-                        INSERT INTO tbl_msyncdb_version (version, module_id) VALUES (1, 'MBSync') AS newVersion
-                        ON DUPLICATE KEY UPDATE version=newVersion.version;
+                        INSERT INTO tbl_msyncdb_version (version, module_id) VALUES (1, 'MBSync')
+                        ON DUPLICATE KEY UPDATE version=1;
                     ]]))
                     updates:start()
                 else
@@ -88,8 +88,8 @@ MSync.modules[info.ModuleIdentifier].init = function( transaction )
                 ]]))
 
                 updates:addQuery( MSync.DBServer:query([[
-                    INSERT INTO tbl_msyncdb_version (version, module_id) VALUES (1, 'MBSync') AS newVersion
-                    ON DUPLICATE KEY UPDATE version=newVersion.version;
+                    INSERT INTO tbl_msyncdb_version (version, module_id) VALUES (1, 'MBSync')
+                    ON DUPLICATE KEY UPDATE version=1;
                 ]]))
                 updates:start()
             end
@@ -690,8 +690,8 @@ MSync.modules[info.ModuleIdentifier].init = function( transaction )
             ]]
             transactions[k..'_user'] = MSync.DBServer:prepare( [[
                 INSERT INTO `tbl_users` (steamid, steamid64, nickname, joined)
-                VALUES (?, ?, ?, ?) AS newUser
-                ON DUPLICATE KEY UPDATE steamid=newUser.steamid;
+                SELECT * FROM (SELECT ? AS steamid, ? AS steamid64, ? AS newNick, ? AS joined) AS dataQuery
+                ON DUPLICATE KEY UPDATE steamid=newNick;
             ]] )
             transactions[k..'_user']:setString(1, k)
             transactions[k..'_user']:setString(2, util.SteamIDTo64( k ))

--- a/lua/msync/server/sv_mysql.lua
+++ b/lua/msync/server/sv_mysql.lua
@@ -44,8 +44,9 @@ function MSync.mysql.initialize()
             ]] ))
 
             initDatabase:addQuery(MSync.DBServer:query( [[
-                INSERT INTO `tbl_server_grp` (group_name) VALUES ('allservers') AS newGroup
-                ON DUPLICATE KEY UPDATE group_name=newGroup.group_name;
+                INSERT INTO `tbl_server_grp` (group_name)
+                SELECT * FROM (SELECT 'allservers' AS newGroup) AS dataQuery
+                ON DUPLICATE KEY UPDATE group_name=newGroup;
             ]] ))
 
             initDatabase:addQuery(MSync.DBServer:query( [[
@@ -74,8 +75,9 @@ function MSync.mysql.initialize()
             ]] ))
 
             initDatabase:addQuery(MSync.DBServer:query( [[
-                INSERT INTO `tbl_users` (steamid, steamid64, nickname, joined) VALUES ('STEAM_0:0:0', '76561197960265728', '(CONSOLE)', '2004-12-24 12:00:00') AS newUser
-                ON DUPLICATE KEY UPDATE nickname=newUser.nickname;
+                INSERT INTO `tbl_users` (steamid, steamid64, nickname, joined)
+                SELECT * FROM (SELECT 'STEAM_0:0:0', '76561197960265728', '(CONSOLE)' AS newUser, '2004-12-24 12:00:00') AS dataQuery
+                ON DUPLICATE KEY UPDATE nickname=newUser;
             ]] ))
 
             function initDatabase.onSuccess()
@@ -115,8 +117,8 @@ function MSync.mysql.addUser(ply)
 
     local addUserQ = MSync.DBServer:prepare( [[
         INSERT INTO `tbl_users` (steamid, steamid64, nickname, joined)
-        VALUES (?, ?, ?, ?) AS newUser
-        ON DUPLICATE KEY UPDATE nickname=newUser.nickname;
+        SELECT * FROM (SELECT ? AS steamid, ? AS steamid64, ? AS newNick, ? AS joined) AS dataQuery
+        ON DUPLICATE KEY UPDATE nickname=newNick;
     ]] )
 
     local nickname = ply:Nick()
@@ -156,8 +158,8 @@ function MSync.mysql.addUserID(steamid, nickname)
 
     local addUserQ = MSync.DBServer:prepare( [[
         INSERT INTO `tbl_users` (steamid, steamid64, nickname, joined)
-        VALUES (?, ?, ?, ?) AS newUser
-        ON DUPLICATE KEY UPDATE nickname=newUser.nickname;
+        SELECT * FROM (SELECT ? AS steamid, ? AS steamid64, ? AS newNick, ? AS joined) AS dataQuery
+        ON DUPLICATE KEY UPDATE nickname=newNick;
     ]] )
 
     if string.len(nickname) > 30 then
@@ -198,8 +200,9 @@ end
 function MSync.mysql.saveServer()
 
     local addServerGroup = MSync.DBServer:prepare( [[
-        INSERT INTO `tbl_server_grp` (group_name) VALUES (?) AS newGroup
-        ON DUPLICATE KEY UPDATE group_name=newGroup.group_name;
+        INSERT INTO `tbl_server_grp` (group_name) 
+        SELECT * FROM (SELECT ? AS newGroup) AS dataQuery
+        ON DUPLICATE KEY UPDATE group_name=newGroup;
     ]] )
     addServerGroup:setString(1, MSync.settings.data.serverGroup)
 


### PR DESCRIPTION
Update SQL syntax to support MySQL below 8.0.19 and MariaDB. The ``AS tbl`` for inserts has only been implemented with MySQL 8.0.19 and thus does not support any prior version or MariaDB.
https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html